### PR TITLE
Closes #15

### DIFF
--- a/lib/actions/bank.actions.ts
+++ b/lib/actions/bank.actions.ts
@@ -150,6 +150,7 @@ export const getInstitution = async ({
 export const getTransactions = async ({
   accessToken,
 }: getTransactionsProps) => {
+  let cursor = undefined;
   let hasMore = true;
   let transactions: any = [];
 
@@ -158,6 +159,7 @@ export const getTransactions = async ({
     while (hasMore) {
       const response = await plaidClient.transactionsSync({
         access_token: accessToken,
+        cursor
       });
 
       const data = response.data;
@@ -176,10 +178,11 @@ export const getTransactions = async ({
       }));
 
       hasMore = data.has_more;
+      cursor = data.next_cursor;
     }
 
     return parseStringify(transactions);
   } catch (error) {
-    console.error("An error occurred while getting the accounts:", error);
+    console.error("An error occurred while getting the transactions:", error);
   }
 };


### PR DESCRIPTION
### Description
The `getTransactions` action is calling the `transactionsSync` endpoint without a cursor, causing the rate limit to be exceeded.

### Changes made
- By adding the cursor value and updating it within the transaction update loop, the transaction syncing can be completed within the rate limit. (see plaid docs: https://plaid.com/docs/api/products/transactions/#transactions-sync-request-cursor)
- Updated the error message within `getTransactions` for clarity