### PR TITLE
Fix Transactions Display Issue

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -138,7 +138,7 @@ export const createLinkToken = async (user: User) => {
         client_user_id: user.$id
       },
       client_name: `${user.firstName} ${user.lastName}`,
-      products: ['auth'] as Products[],
+      products: ['auth', 'transactions'] as Products[],
       language: 'en',
       country_codes: ['US'] as CountryCode[],
     }


### PR DESCRIPTION
The app returns `ADDITIONAL_CONSENT_REQUIRED` when accessing transaction data. This is caused by the [Data Transparency Messaging (DTM)](https://plaid.com/docs/link/data-transparency-messaging-migration-guide/) enforced by Plaid in US and Canada. This change will get the right consent during sign-up phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced financial integration to retrieve transaction data alongside authentication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->