### PR TITLE
fix: Safari mobile auth - change sameSite to none for cross-site OAuth

### DIFF
--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -40,7 +40,7 @@ export const signIn = async ({ email, password }: signInProps) => {
     cookies().set("appwrite-session", session.secret, {
       path: "/",
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "none",
       secure: true,
     });
 
@@ -95,7 +95,7 @@ export const signUp = async ({ password, ...userData }: SignUpParams) => {
     cookies().set("appwrite-session", session.secret, {
       path: "/",
       httpOnly: true,
-      sameSite: "strict",
+      sameSite: "none",
       secure: true,
     });
 


### PR DESCRIPTION
Fixes #247

## Problem
Safari on iOS 17+ blocks cookies with `sameSite="strict"` during OAuth redirects from external providers (Google). This causes the session cookie to be dropped, resulting in users being redirected back to `/sign-in` in a loop after completing authentication.

## Solution
Changed `sameSite` from `"strict"` to `"none"` in both `signIn()` and `signUp()` functions.

## Safety
- Cookies already use `httpOnly=true` and `secure=true`
- `sameSite="none"` is safe when paired with `secure=true`
- This allows cookies to survive cross-site redirects while maintaining security

## Testing
Should be tested on:
- Mobile Safari iOS 17+
- OAuth flow with Google sign-in
- Verify redirect to `/dashboard` after auth

cc @nicholasdev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cookie behavior to support cross-site functionality, enabling improved compatibility with external services and third-party integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->