### PR TITLE
Update MobileNav.tsx  Fix: correct Tailwind class typo (w-fulll )

### DIFF
--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -20,7 +20,7 @@ const MobileNav = ({ user }: MobileNavProps) => {
   const pathname = usePathname();
 
   return (
-    <section className="w-fulll max-w-[264px]">
+    <section className="max-w-[264px]">
       <Sheet>
         <SheetTrigger>
           <Image


### PR DESCRIPTION
This PR fixes a typo in a Tailwind CSS class.

Removed unnecessary `w-fulll` This ensures the element renders with the intended width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved mobile navigation styling issue to ensure proper display and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->